### PR TITLE
fix d2 register restore in draw.s

### DIFF
--- a/fvdi/engine/draw.s
+++ b/fvdi/engine/draw.s
@@ -375,10 +375,11 @@ c_v_pline:
 	jsr	_wide_line
 	add.w	#24,a7
 
+	move.l	(a7)+,d2
+
 	bsr	free_block	; Block address is already on the stack
 	addq.l	#4,a7
 
-	move.l	(a7)+,d2
 	rts
 
 


### PR DESCRIPTION
this (https://github.com/vinriviere/fvdi/blob/88cc1b905f8074965238aca475bb0207f5cc416c/fvdi/engine/draw.s#L381) restore was done too early, effectly calling free_block with a wrong block address.

This caused wide lines to crash