### PR TITLE
Include git commit in startup log message

### DIFF
--- a/fvdi/engine/Makefile
+++ b/fvdi/engine/Makefile
@@ -21,6 +21,12 @@ CFLAGS  = $(CPUOPTS) $(OPTS) $(WARNINGS) -I$(top_srcdir)/include -I$(top_srcdir)
 
 LDFLAGS += --mprg-flags=0x27
 
+ifndef GIT_HASH
+ GIT_HASH := $(shell git describe --always --abbrev=10)
+endif
+
+CPPFLAGS += -DGIT_COMMIT="\"$(GIT_HASH)\""
+
 # FreeType2 things
 ifneq ($(ft2_srcdir),)
  LIBS   := -lft2 $(LIBS)

--- a/fvdi/engine/startup.c
+++ b/fvdi/engine/startup.c
@@ -257,6 +257,9 @@ long startup(void)
     access->funcs.puts("-FT-");
     access->funcs.puts(ft2_version);
 #endif
+#ifdef GIT_COMMIT
+    access->funcs.puts(" (" GIT_COMMIT ")");
+#endif
     access->funcs.puts(" now installed.\n");
 
     if (debug)


### PR DESCRIPTION
Version numbers aren't too helpful identifying a build, especially
if the version doesn't change for a few years.

Adding the git commit hash is a common solution:

```
fVDI v0.970beta3-32bit-gcc-FT-2.10.2 (eb26db352d) now installed.
```