### PR TITLE
Update Freetype from 2.10.2 to 2.10.3 (and everything after)

### DIFF
--- a/fvdi/CONFIGVARS
+++ b/fvdi/CONFIGVARS
@@ -50,7 +50,7 @@ WARNINGS = -Wall -W -Wunused -Wundef -Wstrict-prototypes -Wmissing-prototypes -W
 # Warnings to use when compiling FreeType2 code
 # we do not intend to fix any warnings we inherit from the FreeType2 sources
 # consequently, we suppress most warnings here
-FT2_WARNINGS = -Wstrict-prototypes -Wmissing-prototypes
+FT2_WARNINGS = -Wstrict-prototypes -Wmissing-prototypes -Wno-attributes
 FT2_CFLAGS = -std=gnu99 -DFT2 -I$(top_srcdir)/modules/ft2/include -I$(ft2_srcdir)/include -DFT_CONFIG_CONFIG_H="<freetype/config/ftconfig.h>" -DFT2_BUILD_LIBRARY
 
 ifeq ($(OPTS),)

--- a/fvdi/modules/ft2/Makefile
+++ b/fvdi/modules/ft2/Makefile
@@ -35,7 +35,20 @@ subdir      = ft2
 
 include $(top_srcdir)/CONFIGVARS
 
-CFLAGS = $(CPUOPTS) $(OPTS) $(FT2_WARNINGS) $(FT2_CFLAGS) -I$(top_srcdir)/include -I$(top_srcdir)/modules/include -I$(ft2_srcdir)/src
+ifndef FREETYPE_VERSION
+ifneq (,$(wildcard $(ft2_srcdir)/include/freetype/freetype.h))
+	FREETYPE_MAJOR := $(shell sed -n -e '/define FREETYPE_MAJOR/s/[^0-9]*//p' $(ft2_srcdir)/include/freetype/freetype.h)
+	FREETYPE_MINOR := $(shell sed -n -e '/define FREETYPE_MINOR/s/[^0-9]*//p' $(ft2_srcdir)/include/freetype/freetype.h)
+	FREETYPE_PATCH := $(shell sed -n -e '/define FREETYPE_PATCH/s/[^0-9]*//p' $(ft2_srcdir)/include/freetype/freetype.h)
+else ifneq (,$(wildcard $(ft2_srcdir)/include/freetype.h))
+	FREETYPE_MAJOR := $(shell sed -n -e '/define FREETYPE_MAJOR/s/[^0-9]*//p' $(ft2_srcdir)/include/freetype.h)
+	FREETYPE_MINOR := $(shell sed -n -e '/define FREETYPE_MINOR/s/[^0-9]*//p' $(ft2_srcdir)/include/freetype.h)
+	FREETYPE_PATCH := $(shell sed -n -e '/define FREETYPE_PATCH/s/[^0-9]*//p' $(ft2_srcdir)/include/freetype.h)
+endif
+FREETYPE_VERSION := $(shell printf "%d%03d%03dL" $(FREETYPE_MAJOR) $(FREETYPE_MINOR) $(FREETYPE_PATCH))
+endif
+
+CFLAGS = $(CPUOPTS) $(OPTS) $(FT2_WARNINGS) $(FT2_CFLAGS) -DFREETYPE_VERSION=$(FREETYPE_VERSION) -I$(top_srcdir)/include -I$(top_srcdir)/modules/include -I$(ft2_srcdir)/src
 
 #
 # FreeType2 library base

--- a/fvdi/modules/ft2/ft2_ftdebug.c
+++ b/fvdi/modules/ft2/ft2_ftdebug.c
@@ -43,14 +43,25 @@
 
 #include <ft2build.h>
 #include <freetype/config/ftconfig.h>
+
 #ifdef FT_FREETYPE_H
 #include FT_FREETYPE_H
+#if FREETYPE_VERSION <= 2010002L
 #include FT_INTERNAL_INTERNAL_H
 #include FT_INTERNAL_DEBUG_H
 #else
+#include <freetype/internal/compiler-macros.h>
+#include <freetype/internal/ftdebug.h>
+#endif
+#else
 #include <freetype/freetype.h>
+#if FREETYPE_VERSION <= 2010002L
 #include <freetype/internal/internal.h>
 #include <freetype/internal/ftdebug.h>
+#else
+#include <freetype/internal/compiler-macros.h>
+#include <freetype/internal/ftdebug.h>
+#endif
 #endif
 
 #include "globals.h"

--- a/fvdi/modules/ft2/ft2_ftsystem.c
+++ b/fvdi/modules/ft2/ft2_ftsystem.c
@@ -34,15 +34,17 @@
 #include FT_INTERNAL_INTERNAL_H
 #include FT_INTERNAL_DEBUG_H
 #include FT_SYSTEM_H
-#include FT_ERRORS_H
 #include FT_TYPES_H
+#include FT_ERRORS_H
 #include FT_INTERNAL_STREAM_H
 #else
+#if FREETYPE_VERSION <= 2010002L
 #include <freetype/internal/internal.h>
+#endif
 #include <freetype/internal/ftdebug.h>
 #include <freetype/ftsystem.h>
-#include <freetype/fterrors.h>
 #include <freetype/fttypes.h>
+#include <freetype/fterrors.h>
 #include <freetype/internal/ftstream.h>
 #endif
 

--- a/fvdi/modules/ft2/include/freetype/config/ftconfig.h
+++ b/fvdi/modules/ft2/include/freetype/config/ftconfig.h
@@ -37,7 +37,17 @@
 #define FTCONFIG_H_
 
 #include <ft2build.h>
+#if FREETYPE_VERSION >= 2010003L
 
+#include FT_CONFIG_OPTIONS_H
+#include FT_CONFIG_STANDARD_LIBRARY_H
+
+#include <freetype/config/integer-types.h>
+#include <freetype/config/public-macros.h>
+#include <freetype/config/mac-support.h>
+
+#else
+/* Previous porting */
 #undef FT_CONFIG_OPTIONS_H
 #define FT_CONFIG_OPTIONS_H <freetype/config/ftoption.h>
 #undef FT_CONFIG_CONFIG_H
@@ -793,6 +803,7 @@ FT_BEGIN_HEADER
 
 FT_END_HEADER
 
+#endif
 
 #endif /* __FTCONFIG_H__ */
 

--- a/fvdi/modules/ft2/include/freetype/config/ftmodule.h
+++ b/fvdi/modules/ft2/include/freetype/config/ftmodule.h
@@ -19,8 +19,10 @@ FT_USE_MODULE( FT_Module_Class, pshinter_module_class )
 FT_USE_MODULE( FT_Module_Class, sfnt_module_class )
 FT_USE_MODULE( FT_Renderer_Class, ft_raster1_renderer_class )
 FT_USE_MODULE( FT_Renderer_Class, ft_smooth_renderer_class )
+#if FREETYPE_VERSION <= 2010002L
 FT_USE_MODULE( FT_Renderer_Class, ft_smooth_lcd_renderer_class )
 FT_USE_MODULE( FT_Renderer_Class, ft_smooth_lcdv_renderer_class )
+#endif
 #else
 FT_USE_MODULE(autofit_module_class)
 FT_USE_MODULE(tt_driver_class)
@@ -38,6 +40,4 @@ FT_USE_MODULE(pshinter_module_class)
 FT_USE_MODULE(sfnt_module_class)
 FT_USE_MODULE(ft_raster1_renderer_class)
 FT_USE_MODULE(ft_smooth_renderer_class)
-FT_USE_MODULE(ft_smooth_lcd_renderer_class)
-FT_USE_MODULE(ft_smooth_lcdv_renderer_class)
 #endif


### PR DESCRIPTION
The ftconfig.h file changed significantly in 2.10.3 in a way that I could not find a way
to detect in the preprocessor. Defining the `FREETYPE_VERSION` symbol in `FT_CFLAGS` makes
the subsequent changes easier and relatively readable. The same value format is used as in
the Freetype/fVDI code. This is a little tacky IMO, but only needed because of the need
to test versions quite early during preprocessing.

(In 2.5.x the freetype.h header moved, hence the checks in the Makefile. Sanity prevailed
in 2.6.1.)

Most of the ftconfig.h definitions are now in the new internal compiler-macros.h. Thew new
defs include the use of `__attribute__(( visibility( "hidden" ) ))` which doesn't work
with m68k-atari-mint-gcc10. Adding `-Wno-attributes` to `FT2_WARNINGS` mutes this
apparently harmless warning.

Two lcd smoothing modules have been retired.

After porting to 2.10.3, I found that all subsequent versions now build cleanly. Existing
builds of 2.2.1, 2.5.2, 2.8.1 and 2.10.2 still build.

fvdi_gnu.prg sizes with gcc10 are:

| Version | Binary |
| ------- | ------ |
| 2.2.1   | 413489 |
| 2.5.2   | 552275 |
| 2.8.1   | 544862 |
| 2.10.2  | 571212 |
| 2.10.3  | 572855 |
| 2.10.4  | 572851 |
| 2.11.0  | 577312 |
| 2.11.1  | 572461 |