### PR TITLE
Copy bitplane.sys into install dir

### DIFF
--- a/fvdi/drivers/bitplane/Makefile
+++ b/fvdi/drivers/bitplane/Makefile
@@ -68,5 +68,6 @@ strip:
 clean:: clean_gnu
 	$(RM) $(OBJECTS) $(TARGET)
 
-install:
-	@:
+install::
+	mkdir -p $(DESTDIR)/gemsys
+	cp -a $(TARGET) $(DESTDIR)/gemsys/$(TARGET)


### PR DESCRIPTION
The intention is to cause it to be built into the snapshot archives.